### PR TITLE
add open dataset : 3kricegenome (96.6TiB)

### DIFF
--- a/datasets.md
+++ b/datasets.md
@@ -82,3 +82,4 @@ If you would like to use a dataset that you don't see listed here, please submit
 | Movie Heaven | Movie Paradise is a large online movie broadcasting platform in China | - | Video | https://www.dytt8.net |
 | COCO | COCO is a large-scale object detection, segmentation, and captioning dataset. | - | ZIP | https://cocodataset.org |
 | Google Cloud Public Datasets | Uncover new insights with high-demand public datasets | - | Varies | https://cloud.google.com/public-datasets |
+| 3kricegenome | The 3000 Rice Genome Project is an international effort to sequence the genomes of 3,024 rice varieties from 89 countries. | 96.6 TiB | Varies | https://www.irri.org/ |


### PR DESCRIPTION
Name: 3000 Rice Genomes Project
Description: The 3000 Rice Genome Project is an international effort to sequence the genomes of 3,024 rice varieties from 89 countries.
Documentation: https://docs.opendata.aws/3kricegenome/readme.html
Contact: http://iric.irri.org/contact-us
UpdateFrequency: Not updated
Tags:
  - agriculture
  - food security
  - aws-pds
  - genetic
  - genomic
  - life sciences
License: This data is available for anyone to use under the terms of the Toronto Statement, which is available [here](http://www.nature.com/nature/journal/v461/n7261/box/461168a_BX1.html)
Resources:
  - Description: http://s3.amazonaws.com/3kricegenome/README-snp_pipeline.txt
    ARN: arn:aws:s3:::3kricegenome
    Region: us-east-1
    Type: S3 Bucket
DataAtWork:
  Tutorials:
  Tools & Applications:
    - Title: RiceGalaxy
      URL: https://github.com/InternationalRiceResearchInstitute/RiceGalaxy
      AuthorName: International Rice Research Institute
      AuthorURL: https://www.irri.org/

Dataset Size : 96.6 TiB
Dataset Objects: 80058
@dineshshenoy