### PR TITLE
docs Clarify restore cids

### DIFF
--- a/recovery/README.md
+++ b/recovery/README.md
@@ -31,13 +31,13 @@ File path: recovery/cids/restore/chosen-dataset.csv
 File content: 
 ```
 payload_cid
-bafykbacelmss5jrbnze37rhyiuhat
-bafykbacelmss7s2zmqekui7ysukid
-bafykbacelmssa6xkdvebnzu2xmaol
-bafykbacelmssdtuhui4ea32ohda6z
-bafykbacelmssfokmkaugllwx255ss
-bafykbacelmsskocznkpqc4mj23got
-bafykbacelmssvoooxgbpbt6ps4ump
+bafybeicelmss5jrbnze37rhyiuhat
+bafybeicelmss7s2zmqekui7ysukid
+bafybeicelmssa6xkdvebnzu2xmaol
+bafybeicelmssdtuhui4ea32ohda6z
+bafybeicelmssfokmkaugllwx255ss
+bafybeicelmsskocznkpqc4mj23got
+bafybeicelmssvoooxgbpbt6ps4ump
 ```
 
 

--- a/recovery/README.md
+++ b/recovery/README.md
@@ -3,6 +3,8 @@ The Slingshot Recovery effort includes the Restore and Repair programs. You can 
 - [Slingshot Restore](https://docs.google.com/document/d/1sGLkw321Fl09jvAr80kFY2FcQWa1H-dYpowXFRWo-OM/edit?usp=sharing)
 - [Slingshot Repair](https://docs.google.com/document/d/1ZH4URWaNYtlddZwZMyqcSnc3GRsR3zCqnW0RfkkNlr8/edit?usp=sharing)
 
+A dashboard displaying progress for both Slingshot Restore and Slingshot Repair is available at [slingshot.filecoin.io/recovery](https://slingshot.filecoin.io/recovery).
+
 ## Restore
 If you're a client participating in the Slingshot Restore Program, this directory has the metadata used to track your deals on chain. Please feel free to create pull requests for the following scenarios.
 
@@ -13,7 +15,10 @@ If you need to update the list of payload CIDs being tracked for your dataset on
 - The file name should match your assigned dataset name, in kebab-case (also referred to as the dataset-slug)
   - check your dataset-slug in the [Client Info spreadsheet](https://docs.google.com/spreadsheets/d/1LWVndxGyegTdz5cPU86UZ5Y9vqN2n-VlK1kC0OeJHC8/edit?usp=sharing) or  [the recovery dataset list](https://github.com/filecoin-project/slingshot/blob/master/recovery/files/dataset-list.json)
 - All CIDs must be **base32 CID v1's** only (i.e., `ba...`)
-- Submit payload CIDs only (not piece CIDs)
+- Submit payload CIDs only (these will most likely begin with `bafyk...` or `bafyb...`)
+  - Not piece CIDs
+  - Not deal proposal CIDs (CIDs beginning with `baga...` or `bafyr...` are incorrect)
+  - If your payload CIDs are in `Qm...` format, they must be converted to `base 32` CIDv1's; if you've installed [cid-tool](https://www.npmjs.com/package/cid-tool), you can run `cid base32 Qm...` to convert
 - If you need to add more CIDs, simply create another PR and append to your existing file
 - Your file's first row should say `payload_cid`
 - Submit only one column (just the `payload_cid` and no additional content)


### PR DESCRIPTION
- Adds to the Slingshot Restore readme and clarifies what a correct CID should look like
- Includes notes that clarify what an incorrect CID looks like, since deal proposal CIDs were being submitted accidentally