### PR TITLE
feat: Add newly proposed datasets for 2.8

### DIFF
--- a/datasets.md
+++ b/datasets.md
@@ -48,7 +48,7 @@ In an effort to continue diversifying the data being onboarded onto the network,
 | NEXRAD | Next Generation Weather Radar is a network of 160 high-resolution S-band Doppler weather radars that detect precipitation and wind patterns and movemement. | 2 PB (approx) | Various | https://registry.opendata.aws/noaa-nexrad |
 | NASA NEX | A collection of Earth science datasets maintained by NASA, including climate change projections and satellite images of the Earth's surface. | 55.9 TiB | Various | https://registry.opendata.aws/nasanex |
 | Terra Fusion Data Sampler | Data from Terra, the flagship of NASA’s Earth Observing System (EOS). Each Level 1 Terra Basic Fusion file contains one full Terra orbit of data. | 136.2 TiB | hdf | https://registry.opendata.aws/terrafusion |
-
+| Brazil Data Cube | A research, development and technological innovation project of the National Institute for Space Research (INPE), Brazil, producing datasets from big volumes of medium-resolution remote sensing images. | 112.9 TiB | tiff | https://registry.opendata.aws/brazil-data-cubes |
 
 ## Deprioritized datasets
 

--- a/datasets.md
+++ b/datasets.md
@@ -5,6 +5,7 @@ There are a wide variety of public data sets that can be leveraged for this chal
 
 If you would like to use a dataset that you don't see listed here, please submit an issue to add the dataset to this table. In order to qualify for Slingshot,  a dataset should generally be a public good dataset, be accessible to everyone, and not require any special permissions to access. If you are using your own data that you are willing to make public but does not have a source URL, then please share a link to download it in the Link to Dataset field.
 
+
 ## Current qualifying datasets
 
 In an effort to continue diversifying the data being onboarded onto the network, the list of qualifying datasets changes over time as participating teams onboard more data onto the network! Datasets that qualified in previous phases of Slingshot and no longer qualify as listed separately below.
@@ -47,6 +48,7 @@ In an effort to continue diversifying the data being onboarded onto the network,
 | NEXRAD | Next Generation Weather Radar is a network of 160 high-resolution S-band Doppler weather radars that detect precipitation and wind patterns and movemement. | 2 PB (approx) | Various | https://registry.opendata.aws/noaa-nexrad |
 | NASA NEX | A collection of Earth science datasets maintained by NASA, including climate change projections and satellite images of the Earth's surface. | 55.9 TiB | Various | https://registry.opendata.aws/nasanex |
 | Terra Fusion Data Sampler | Data from Terra, the flagship of NASA’s Earth Observing System (EOS). Each Level 1 Terra Basic Fusion file contains one full Terra orbit of data. | 136.2 TiB | hdf | https://registry.opendata.aws/terrafusion |
+
 
 ## Deprioritized datasets
 
@@ -97,6 +99,7 @@ These datasets have been temporarily disqualified for the current phase of the c
 | CLEVR Dataset | A Diagnostic Dataset for Compositional Language and Elementary Visual Reasoning. | 19 GB | png&json | https://www.kaggle.com/timoboz/clevr-dataset |
 | COCO2017 | Common Objects in Context | 20 GB | jpg | https://www.kaggle.com/aishwr/coco2017 |
 | SmartCity Dataset | Noise data collected by fiber optic sensing equipment for research | 200 TB (approx) | WAV | http://api.sr2.glm2m.com/index.php?r=smartcity-dataset%2Fdataset |
+
 
 ## Disqualified datasets
 

--- a/datasets.md
+++ b/datasets.md
@@ -44,6 +44,9 @@ In an effort to continue diversifying the data being onboarded onto the network,
 | SnpEff | Genomic variant annotations and functional effect prediction toolbox | 2TiB | vcf | https://docs.microsoft.com/en-us/azure/open-datasets/dataset-snpeff |
 | Russian Open Speech To Text | A collection of speech samples derived from various audio sources. The dataset contains short audio clips in Russian. | 3TiB | wav/opus | https://docs.microsoft.com/en-us/azure/open-datasets/dataset-open-speech-text |
 | TartanAir | AirSim simulation dataset for simultaneous localization and mapping (SLAM) | 3TiB | png/npy/txt | https://docs.microsoft.com/en-us/azure/open-datasets/dataset-tartanair-simulation |
+| NEXRAD | Next Generation Weather Radar is a network of 160 high-resolution S-band Doppler weather radars that detect precipitation and wind patterns and movemement. | 2 PB (approx) | Various | https://registry.opendata.aws/noaa-nexrad |
+| NASA NEX | A collection of Earth science datasets maintained by NASA, including climate change projections and satellite images of the Earth's surface. | 55.9 TiB | Various | https://registry.opendata.aws/nasanex |
+| Terra Fusion Data Sampler | Data from Terra, the flagship of NASA’s Earth Observing System (EOS). Each Level 1 Terra Basic Fusion file contains one full Terra orbit of data. | 136.2 TiB | hdf | https://registry.opendata.aws/terrafusion |
 
 ## Deprioritized datasets
 
@@ -94,7 +97,6 @@ These datasets have been temporarily disqualified for the current phase of the c
 | CLEVR Dataset | A Diagnostic Dataset for Compositional Language and Elementary Visual Reasoning. | 19 GB | png&json | https://www.kaggle.com/timoboz/clevr-dataset |
 | COCO2017 | Common Objects in Context | 20 GB | jpg | https://www.kaggle.com/aishwr/coco2017 |
 | SmartCity Dataset | Noise data collected by fiber optic sensing equipment for research | 200 TB (approx) | WAV | http://api.sr2.glm2m.com/index.php?r=smartcity-dataset%2Fdataset |
-
 
 ## Disqualified datasets
 


### PR DESCRIPTION
Adds three new datasets for use in phase 2.8 of Slingshot

- NEXRAD `nexrad`
- NASA NEX `nasa-nex`
- Terra Fusion Data Sampler `terra-fusion-data-sampler`
- Brazil Data Cube `brazil-data-cube`